### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,8 +6,8 @@
 		<title>{{ .Title }} &middot; {{ .Site.Title }}</title>
 		<link rel="canonical" href="{{ .Permalink }}">
 		<link rel="stylesheet" type="text/css" href="/css/main.css" />
-		{{ if .RSSlink }}
-			<link href="{{ .RSSlink }}" rel="alternative" type="application/rss+xml" title="{{ .Title }}" />
+		{{ if .RSSLink }}
+			<link href="{{ .RSSLink }}" rel="alternative" type="application/rss+xml" title="{{ .Title }}" />
 		{{ end }}
 		{{ partial "head.html" . }}
 	</head>


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.